### PR TITLE
Added support for building using the dotnet cli.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,3 @@
 ﻿{
-  "projects": [ "source", "test", "samples" ],
-  "sdk": {
-    "version": "1.0.0-rc1-final"
-  }
+  "projects": [ "source", "test", "samples" ]
 }

--- a/samples/IrcDotNet.Samples.Common/IrcBot.cs
+++ b/samples/IrcDotNet.Samples.Common/IrcBot.cs
@@ -35,13 +35,13 @@ namespace IrcDotNet
         {
             this.isRunning = false;
             this.commandProcessors = new Dictionary<string, CommandProcessor>(
-                StringComparer.InvariantCultureIgnoreCase);
+                StringComparer.OrdinalIgnoreCase);
             InitializeCommandProcessors();
 
             this.allClients = new Collection<IrcClient>();
             this.allClientsReadOnly = new ReadOnlyCollection<IrcClient>(this.allClients);
             this.chatCommandProcessors = new Dictionary<string, ChatCommandProcessor>(
-                StringComparer.InvariantCultureIgnoreCase);
+                StringComparer.OrdinalIgnoreCase);
             InitializeChatCommandProcessors();
         }
 

--- a/samples/IrcDotNet.Samples.Common/IrcDotNet.Samples.Common.xproj
+++ b/samples/IrcDotNet.Samples.Common/IrcDotNet.Samples.Common.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>79d383d5-af2a-4d3a-991c-d1588c0e220d</ProjectGuid>
     <RootNamespace>IrcDotNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/samples/IrcDotNet.Samples.Common/ProgramInfo.cs
+++ b/samples/IrcDotNet.Samples.Common/ProgramInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 
 namespace IrcDotNet
@@ -9,8 +10,13 @@ namespace IrcDotNet
         {
             get
             {
+#if NETSTANDARD1_5
+                return ((AssemblyTitleAttribute)Assembly.GetEntryAssembly().GetCustomAttributes(
+                    typeof(AssemblyTitleAttribute)).First()).Title;
+#else
                 return ((AssemblyTitleAttribute)Assembly.GetEntryAssembly().GetCustomAttributes(
                     typeof(AssemblyTitleAttribute), false)[0]).Title;
+#endif
             }
         }
 
@@ -18,8 +24,13 @@ namespace IrcDotNet
         {
             get
             {
+#if NETSTANDARD1_5
+                return ((AssemblyCopyrightAttribute)Assembly.GetEntryAssembly().GetCustomAttributes(
+                    typeof(AssemblyCopyrightAttribute)).First()).Copyright;
+#else
                 return ((AssemblyCopyrightAttribute)Assembly.GetEntryAssembly().GetCustomAttributes(
                     typeof(AssemblyCopyrightAttribute), false)[0]).Copyright;
+#endif
             }
         }
 

--- a/samples/IrcDotNet.Samples.Common/Properties/Resources.Designer.cs
+++ b/samples/IrcDotNet.Samples.Common/Properties/Resources.Designer.cs
@@ -38,7 +38,11 @@ namespace IrcDotNet.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
+#if NETSTANDARD1_5
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+#else
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).Assembly);
+#endif
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/samples/IrcDotNet.Samples.Common/project.json
+++ b/samples/IrcDotNet.Samples.Common/project.json
@@ -1,27 +1,34 @@
 ﻿{
   "version": "0.6-*",
 
-  "summary": "Common files for IrcDotNet samples.",
-  "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
-  "authors": [ "Alexander Regueiro", "Christian Stewart" ],
-  "owners": [ "Alexander Regueiro", "Christian Stewart" ],
-  "tags": [ "communication", "irc", "networking", "ctcp" ],
+  "packOptions": {
+    "summary": "Common files for IrcDotNet samples.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
 
-  "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
-  "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+    "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
 
-  "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
-  "requireLicenseAcceptance": true,
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
+  },
 
   "frameworks": {
     "net40": { },
     "net45": { },
     "net451": { },
-    "dnx451": { },
-    "dnx50": { }
+    "netstandard1.5": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      }
+    }
   },
 
   "dependencies": {
-    "IrcDotNet": ""
+    "IrcDotNet": {
+      "target": "project"
+    }
   }
 }

--- a/samples/IrcDotNet.Samples.MarkovTextBot/IrcDotNet.Samples.MarkovChainTextBot.xproj
+++ b/samples/IrcDotNet.Samples.MarkovTextBot/IrcDotNet.Samples.MarkovChainTextBot.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>ba6abc78-0882-4b9e-851b-1735f049a7f2</ProjectGuid>
     <RootNamespace>IrcDotNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/samples/IrcDotNet.Samples.MarkovTextBot/MarkovChainTextBot.cs
+++ b/samples/IrcDotNet.Samples.MarkovTextBot/MarkovChainTextBot.cs
@@ -121,7 +121,7 @@ namespace IrcDotNet
                             continue;
                         // Ignore word if it is first in sentence and same as nick name.
                         if (lastWord == null && channel.Users.Any(cu => cu.User.NickName.Equals(w,
-                            StringComparison.InvariantCultureIgnoreCase)))
+                            StringComparison.OrdinalIgnoreCase)))
                             break;
 
                         markovChain.Train(lastWord, w);

--- a/samples/IrcDotNet.Samples.MarkovTextBot/Properties/Resources.Designer.cs
+++ b/samples/IrcDotNet.Samples.MarkovTextBot/Properties/Resources.Designer.cs
@@ -38,7 +38,11 @@ namespace IrcDotNet.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
+#if NETCOREAPP
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+#else
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).Assembly);
+#endif
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/samples/IrcDotNet.Samples.MarkovTextBot/project.json
+++ b/samples/IrcDotNet.Samples.MarkovTextBot/project.json
@@ -1,35 +1,44 @@
 ﻿{
   "version": "0.6-*",
 
-  "summary": "IrcDotNet markov chain sample.",
-  "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
-  "authors": [ "Alexander Regueiro", "Christian Stewart" ],
-  "owners": [ "Alexander Regueiro", "Christian Stewart" ],
-  "tags": [ "communication", "irc", "networking", "ctcp" ],
+  "packOptions": {
+    "summary": "IrcDotNet markov chain sample.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
 
-  "compilationOptions": {
-    "emitEntryPoint": true
+    "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
   },
 
-  "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
-  "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
-
-  "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
-  "requireLicenseAcceptance": true,
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
 
   "frameworks": {
     "net40": { },
     "net45": { },
     "net451": { },
-    "dnx451": { },
-    "dnx50": { }
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "buildOptions": {
+        "define": [ "NETCOREAPP" ]
+      }
+    }
   },
 
   "dependencies": {
-    "IrcDotNet.Samples.Common": ""
-  },
-
-  "commands": {
-    "IrcDotNet.Samples.MarkovChainTextBot": "IrcDotNet.Samples.MarkovChainTextBot"
+    "IrcDotNet.Samples.Common": {
+      "target": "project"
+    }
   }
 }

--- a/samples/IrcDotNet.Samples.TwitchChat/IrcDotNet.Samples.TwitchChat.xproj
+++ b/samples/IrcDotNet.Samples.TwitchChat/IrcDotNet.Samples.TwitchChat.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>2c2d7884-8bab-488d-a491-f1f0d9139eb7</ProjectGuid>
     <RootNamespace>IrcDotNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/samples/IrcDotNet.Samples.TwitchChat/project.json
+++ b/samples/IrcDotNet.Samples.TwitchChat/project.json
@@ -1,35 +1,41 @@
 ﻿{
   "version": "0.6-*",
 
-  "summary": "IrcDotNet twitch chat example.",
-  "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
-  "authors": [ "Alexander Regueiro", "Christian Stewart" ],
-  "owners": [ "Alexander Regueiro", "Christian Stewart" ],
-  "tags": [ "communication", "irc", "networking", "ctcp" ],
+  "packOptions": {
+    "summary": "IrcDotNet twitch chat example.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
 
-  "compilationOptions": {
-    "emitEntryPoint": true
+    "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
   },
 
-  "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
-  "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
-
-  "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
-  "requireLicenseAcceptance": true,
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
 
   "frameworks": {
     "net40": { },
     "net45": { },
     "net451": { },
-    "dnx451": { },
-    "dnx50": { }
+    "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      }
+    }
   },
 
   "dependencies": {
-    "IrcDotNet.Samples.Common": ""
-  },
-
-  "commands": {
-    "IrcDotNet.Samples.TwitchChat": "IrcDotNet.Samples.TwitchChat"
+    "IrcDotNet.Samples.Common": {
+      "target": "project"
+    }
   }
 }

--- a/samples/IrcDotNet.Samples.TwitterBot/IrcDotNet.Samples.TwitterBot.xproj
+++ b/samples/IrcDotNet.Samples.TwitterBot/IrcDotNet.Samples.TwitterBot.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>1c3d933f-cb6a-4dca-ac66-37ab0aa0f025</ProjectGuid>
     <RootNamespace>IrcDotNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/samples/IrcDotNet.Samples.TwitterBot/Properties/Resources.Designer.cs
+++ b/samples/IrcDotNet.Samples.TwitterBot/Properties/Resources.Designer.cs
@@ -38,7 +38,11 @@ namespace IrcDotNet.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
+#if NETCOREAPP
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+#else
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).Assembly);
+#endif
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/samples/IrcDotNet.Samples.TwitterBot/project.json
+++ b/samples/IrcDotNet.Samples.TwitterBot/project.json
@@ -1,38 +1,36 @@
 ﻿{
   "version": "0.6-*",
 
-  "summary": "IrcDotNet twitter bot example.",
-  "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
-  "authors": [ "Alexander Regueiro", "Christian Stewart" ],
-  "owners": [ "Alexander Regueiro", "Christian Stewart" ],
-  "tags": [ "communication", "irc", "networking", "ctcp" ],
+  "packOptions": {
+    "summary": "IrcDotNet twitter bot example.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
 
-  "compilationOptions": {
-    "emitEntryPoint": true
+    "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
   },
 
-  "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
-  "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
-
-  "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
-  "requireLicenseAcceptance": true,
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
 
   "frameworks": {
     "net40": { },
     "net45": { },
-    "net451": { },
-    "dnx451": { },
-    "dnx50": { }
+    "net451": { }
   },
 
   "dependencies": {
-    "IrcDotNet.Samples.Common": "",
+    "IrcDotNet.Samples.Common": {
+      "target": "project"
+    },
     "Hammock": "1.3.1",
     "Newtonsoft.Json": "5.0.6",
     "TweetSharp": "2.3.1"
-  },
-
-  "commands": {
-    "IrcDotNet.Samples.TwitterBot": "IrcDotNet.Samples.TwitterBot"
   }
 }

--- a/source/IrcDotNet/CircularBufferStream.cs
+++ b/source/IrcDotNet/CircularBufferStream.cs
@@ -103,7 +103,7 @@ namespace IrcDotNet
                 var newWritePosition = (writePosition + writeCount)%Buffer.Length;
                 if (newWritePosition > readPosition && oldWritePosition < readPosition)
                 {
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
                     throw new InternalBufferOverflowException("The CircularBuffer was overflowed!");
 #else
                     throw new IOException("The CircularBuffer was overflowed!");

--- a/source/IrcDotNet/Collections/ReadOnlyDictionary.cs
+++ b/source/IrcDotNet/Collections/ReadOnlyDictionary.cs
@@ -2,8 +2,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+
+#if !NETSTANDARD1_5
 using System.Runtime.Serialization;
-using System.Text;
+#endif
 
 namespace IrcDotNet.Collections
 {
@@ -12,13 +14,13 @@ namespace IrcDotNet.Collections
     /// </summary>
     /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
     /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable()]
 #endif
     [DebuggerDisplay("Count = {Count}")]
     public class ReadOnlyDictionary<TKey, TValue> : IDictionary<TKey, TValue>, ICollection<KeyValuePair<TKey, TValue>>,
         IEnumerable<KeyValuePair<TKey, TValue>>, IDictionary, ICollection, IEnumerable
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
         , ISerializable, IDeserializationCallback
 #endif
     {
@@ -38,7 +40,7 @@ namespace IrcDotNet.Collections
             this.dictionary = dictionary;
         }
 
-        #region IDictionary<TKey, TValue> Members
+#region IDictionary<TKey, TValue> Members
 
         /// <summary>
         /// Gets a collection containing the keys in the dictionary.
@@ -119,9 +121,9 @@ namespace IrcDotNet.Collections
             throw new NotSupportedException();
         }
 
-        #endregion
+#endregion
 
-        #region ICollection<KeyValuePair<TKey, TValue>> Members
+#region ICollection<KeyValuePair<TKey, TValue>> Members
 
         /// <summary>
         /// Gets the number of key/value pairs contained in the dictionary.
@@ -162,9 +164,9 @@ namespace IrcDotNet.Collections
             this.dictionary.CopyTo(array, arrayIndex);
         }
 
-        #endregion
+#endregion
 
-        #region IEnumerable<KeyValuePair<TKey, TValue>> Members
+#region IEnumerable<KeyValuePair<TKey, TValue>> Members
 
         /// <summary>
         /// Returns an enumerator that iterates through the dictionary.
@@ -175,9 +177,9 @@ namespace IrcDotNet.Collections
             return ((IEnumerable<KeyValuePair<TKey, TValue>>)this.dictionary).GetEnumerator();
         }
 
-        #endregion
+#endregion
 
-        #region IDictionary Members
+#region IDictionary Members
 
         ICollection IDictionary.Keys
         {
@@ -236,9 +238,9 @@ namespace IrcDotNet.Collections
             return ((IDictionary)this.dictionary).GetEnumerator();
         }
 
-        #endregion
+#endregion
 
-        #region ICollection Members
+#region ICollection Members
 
         void ICollection.CopyTo(Array array, int index)
         {
@@ -260,36 +262,36 @@ namespace IrcDotNet.Collections
             get { return ((ICollection)this.dictionary).SyncRoot; }
         }
 
-        #endregion
+#endregion
 
-        #region IEnumerable Members
+#region IEnumerable Members
 
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((IEnumerable)this.dictionary).GetEnumerator();
         }
 
-        #endregion
+#endregion
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
 
-        #region ISerializable Members
+#region ISerializable Members
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             ((ISerializable)this.dictionary).GetObjectData(info, context);
         }
 
-        #endregion
+#endregion
 
-        #region IDeserializationCallback Members
+#region IDeserializationCallback Members
 
         void IDeserializationCallback.OnDeserialization(object sender)
         {
             ((IDeserializationCallback)this.dictionary).OnDeserialization(sender);
         }
 
-        #endregion
+#endregion
 
 #endif
     }

--- a/source/IrcDotNet/Collections/ReadOnlySet.cs
+++ b/source/IrcDotNet/Collections/ReadOnlySet.cs
@@ -2,8 +2,11 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.Serialization;
 using System.Text;
+
+#if !NETSTANDARD1_5
+using System.Runtime.Serialization;
+#endif
 
 namespace IrcDotNet.Collections
 {
@@ -11,12 +14,12 @@ namespace IrcDotNet.Collections
     /// Represents a read-only set of values.
     /// </summary>
     /// <typeparam name="T">The type of elements in the set.</typeparam>
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
     [Serializable()]
 #endif
     [DebuggerDisplay("Count = {Count}")]
     public class ReadOnlySet<T> : ISet<T>, ICollection<T>, IEnumerable<T>, ICollection, IEnumerable
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
         , ISerializable, IDeserializationCallback
 #endif
     {
@@ -55,7 +58,7 @@ namespace IrcDotNet.Collections
             return sb.ToString();
         }
 
-        #region ISet<T> Members
+#region ISet<T> Members
 
         bool ISet<T>.Add(T item)
         {
@@ -184,9 +187,9 @@ namespace IrcDotNet.Collections
             return this.set.SetEquals(other);
         }
 
-        #endregion
+#endregion
 
-        #region ICollection<T> Members
+#region ICollection<T> Members
 
         /// <summary>
         /// Gets the number of elements that are contained in the set.
@@ -256,9 +259,9 @@ namespace IrcDotNet.Collections
             this.set.CopyTo(array, arrayIndex);
         }
 
-        #endregion
+#endregion
 
-        #region IEnumerable<T> Members
+#region IEnumerable<T> Members
 
         /// <summary>
         /// Returns an enumerator that iterates through the set.
@@ -269,9 +272,9 @@ namespace IrcDotNet.Collections
             return ((IEnumerable<T>)this.set).GetEnumerator();
         }
 
-        #endregion
+#endregion
 
-        #region ICollection Members
+#region ICollection Members
 
         void ICollection.CopyTo(Array array, int index)
         {
@@ -288,36 +291,36 @@ namespace IrcDotNet.Collections
             get { return this.syncRoot; }
         }
 
-        #endregion
+#endregion
 
-        #region IEnumerable Members
+#region IEnumerable Members
 
         IEnumerator IEnumerable.GetEnumerator()
         {
             return ((IEnumerable)this.set).GetEnumerator();
         }
 
-        #endregion
+#endregion
 
-#if !SILVERLIGHT
+#if !SILVERLIGHT && !NETSTANDARD1_5
 
-        #region ISerializable Members
+#region ISerializable Members
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
             ((ISerializable)this.set).GetObjectData(info, context);
         }
 
-        #endregion
+#endregion
 
-        #region IDeserializationCallback Members
+#region IDeserializationCallback Members
 
         void IDeserializationCallback.OnDeserialization(object sender)
         {
             ((IDeserializationCallback)this.set).OnDeserialization(sender);
         }
 
-        #endregion
+#endregion
 
 #endif
     }

--- a/source/IrcDotNet/Ctcp/CtcpClient.cs
+++ b/source/IrcDotNet/Ctcp/CtcpClient.cs
@@ -69,7 +69,7 @@ namespace IrcDotNet.Ctcp
 
             IrcClient = ircClient;
             messageProcessors = new Dictionary<string, MessageProcessor>(
-                StringComparer.InvariantCultureIgnoreCase);
+                StringComparer.OrdinalIgnoreCase);
 
             InitializeMessageProcessors();
 

--- a/source/IrcDotNet/IrcClient.cs
+++ b/source/IrcDotNet/IrcClient.cs
@@ -81,7 +81,7 @@ namespace IrcDotNet
         {
             TextEncoding = Encoding.UTF8;
             messageProcessors = new Dictionary<string, MessageProcessor>(
-                StringComparer.InvariantCultureIgnoreCase);
+                StringComparer.OrdinalIgnoreCase);
             numericMessageProcessors = new Dictionary<int, MessageProcessor>(1000);
             FloodPreventer = null;
 

--- a/source/IrcDotNet/IrcDotNet.xproj
+++ b/source/IrcDotNet/IrcDotNet.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>16c78b4c-e12e-4dc1-80bd-db5ae257a1c3</ProjectGuid>
     <RootNamespace>IrcDotNet</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/source/IrcDotNet/Properties/Resources.Designer.cs
+++ b/source/IrcDotNet/Properties/Resources.Designer.cs
@@ -8,6 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System.Reflection;
+
 namespace IrcDotNet.Properties {
     using System;
     
@@ -39,7 +41,11 @@ namespace IrcDotNet.Properties {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
+#if NETSTANDARD1_5
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).GetTypeInfo().Assembly);
+#else
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("IrcDotNet.Properties.Resources", typeof(Resources).Assembly);
+#endif
                     resourceMan = temp;
                 }
                 return resourceMan;

--- a/source/IrcDotNet/ReflectionUtilities.cs
+++ b/source/IrcDotNet/ReflectionUtilities.cs
@@ -13,16 +13,26 @@ namespace IrcDotNet
             where TDelegate : class
         {
             // Find all methods in class that are marked by one or more instances of given attribute.
+#if NETSTANDARD1_5
+            var messageProcessorsMethods = obj.GetType().GetTypeInfo().GetMethods(
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+#else
             var messageProcessorsMethods = obj.GetType().GetMethods(BindingFlags.Instance | BindingFlags.NonPublic
                                                                     | BindingFlags.Public);
+#endif
             foreach (var methodInfo in messageProcessorsMethods)
             {
                 var methodAttributes = (TAttribute[]) methodInfo.GetCustomAttributes(
                     typeof (TAttribute), true);
                 if (methodAttributes.Length > 0)
                 {
+#if NETSTANDARD1_5
+                    var methodDelegate =
+                        (TDelegate)(object)methodInfo.CreateDelegate(typeof(TDelegate), obj);
+#else
                     var methodDelegate =
                         (TDelegate) (object) Delegate.CreateDelegate(typeof (TDelegate), obj, methodInfo);
+#endif
 
                     // Get each attribute applied to method.
                     foreach (var attribute in methodAttributes)

--- a/source/IrcDotNet/project.json
+++ b/source/IrcDotNet/project.json
@@ -1,27 +1,35 @@
 ﻿{
   "version": "0.6.0",
-  "releaseNotes": "https://github.com/IrcDotNet/IrcDotNet/releases/tag/0.6.0",
 
-  "summary": "A complete IRC (Internet Relay Chat) client library for the .NET Framework",
-  "description": "IRC.NET aims to provide a complete and efficient implementation of the protocol as described in RFCs 1459 and 2812, as well as de-facto modern features of the protocol.",
-  "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
-  "authors": [ "Alexander Regueiro", "Christian Stewart" ],
-  "owners": [ "Alexander Regueiro", "Christian Stewart" ],
-  "tags": [ "communication", "irc", "networking", "ctcp" ],
+  "packOptions": {
+    "releaseNotes": "https://github.com/IrcDotNet/IrcDotNet/releases/tag/0.6.0",
 
-  "projectUrl": "https://IrcDotNet.github.io/IrcDotNet/",
-  "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+    "summary": "A complete IRC (Internet Relay Chat) client library for the .NET Framework",
+    "description": "IRC.NET aims to provide a complete and efficient implementation of the protocol as described in RFCs 1459 and 2812, as well as de-facto modern features of the protocol.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
+    "projectUrl": "https://IrcDotNet.github.io/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
 
-  "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
-  "requireLicenseAcceptance": true,
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
+  },
 
   "frameworks": {
     "net40": { },
     "net45": { },
     "net451": { },
-    "dnx451": { }
+    "netstandard1.5": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0",
+        "System.Net.Security": "4.0.0",
+        "System.Net.Requests": "4.0.11",
+        "System.Net.NameResolution": "4.0.0"
+      }
+    }
   },
 
-  "dependencies": {
-  }
+  "dependencies": { }
 }

--- a/test/IrcDotNet.Test/IrcClientTestSet.cs
+++ b/test/IrcDotNet.Test/IrcClientTestSet.cs
@@ -251,7 +251,12 @@ namespace IrcDotNet.Test
 
         private static void ircClient1_Error(object sender, IrcErrorEventArgs e)
         {
-            if (!client2ErrorEvent.SafeWaitHandle.IsClosed)
+#if NETCOREAPP
+            var handle = client1ErrorEvent.GetSafeWaitHandle();
+#else
+            var handle = client1ErrorEvent.SafeWaitHandle;
+#endif
+            if (!handle.IsClosed)
             {
                 if (client1ErrorEvent != null)
                     client1ErrorEvent.Set();
@@ -482,9 +487,9 @@ namespace IrcDotNet.Test
                 client1ChannelNoticeReceivedEvent.Set();
         }
 
-        #endregion
+#endregion
 
-        #region IRC Client 2 Event Handlers
+#region IRC Client 2 Event Handlers
 
         private static void ircClient2_Connected(object sender, EventArgs e)
         {
@@ -506,7 +511,12 @@ namespace IrcDotNet.Test
 
         private static void ircClient2_Error(object sender, IrcErrorEventArgs e)
         {
-            if (!client2ErrorEvent.SafeWaitHandle.IsClosed)
+#if NETCOREAPP
+            var handle = client2ErrorEvent.GetSafeWaitHandle();
+#else
+            var handle = client2ErrorEvent.SafeWaitHandle;
+#endif
+            if (!handle.IsClosed)
             {
                 if (client2ErrorEvent != null)
                     client2ErrorEvent.Set();
@@ -615,9 +625,9 @@ namespace IrcDotNet.Test
                 client2ChannelNoticeReceivedEvent.Set();
         }
 
-        #endregion
+#endregion
 
-        #region CTCP Client 1 Event Handlers
+#region CTCP Client 1 Event Handlers
 
         private static void ctcpClient1_PingResponseReceived(object sender, CtcpPingResponseReceivedEventArgs e)
         {
@@ -655,9 +665,9 @@ namespace IrcDotNet.Test
                 ctcpClient1ActionReceivedEvent.Set();
         }
 
-        #endregion
+#endregion
 
-        #region CTCP Client 2 Event Handlers
+#region CTCP Client 2 Event Handlers
 
         private static void ctcpClient2_PingResponseReceived(object sender, CtcpPingResponseReceivedEventArgs e)
         {
@@ -683,7 +693,7 @@ namespace IrcDotNet.Test
                 ctcpClient2ActionReceivedEvent.Set();
         }
 
-        #endregion
+#endregion
 
         public IrcClientTestSet()
             : base()
@@ -702,7 +712,7 @@ namespace IrcDotNet.Test
         {
         }
 
-        #region Test Methods
+#region Test Methods
 
         [Test]
         [Category("Integration")]
@@ -1202,7 +1212,7 @@ namespace IrcDotNet.Test
             Assert.AreEqual(testMessage1, client2ReceivedActionText);
         }
 
-        #endregion
+#endregion
 
         private bool WaitForClientEvent(WaitHandle eventHandle, int millisecondsTimeout = Timeout.Infinite)
         {

--- a/test/IrcDotNet.Test/IrcDotNet.Test.xproj
+++ b/test/IrcDotNet.Test/IrcDotNet.Test.xproj
@@ -9,7 +9,7 @@
     <ProjectGuid>e7f4f8a2-c7a7-4c01-a412-1e428f51b692</ProjectGuid>
     <RootNamespace>IrcDotNet.Test</RootNamespace>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
   </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>

--- a/test/IrcDotNet.Test/Runner.cs
+++ b/test/IrcDotNet.Test/Runner.cs
@@ -1,4 +1,7 @@
-﻿using NUnitLite;
+﻿using System;
+using System.Reflection;
+using NUnit.Common;
+using NUnitLite;
 
 namespace IrcDotNet.Test
 {
@@ -6,7 +9,11 @@ namespace IrcDotNet.Test
     {
         public static int Main(string[] args)
         {
+#if NETCOREAPP
+            return new AutoRun(typeof(Runner).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
+#else
             return new AutoRun().Execute(args);
+#endif
         }
     }
 }

--- a/test/IrcDotNet.Test/project.json
+++ b/test/IrcDotNet.Test/project.json
@@ -1,25 +1,45 @@
 ﻿{
   "version": "0.6-*",
 
-  "description": "IrcDotNet Tests",
-  "authors": [ "paralin" ],
+  "packOptions": {
+    "summary": "Integration tests for the IrcDotNet library.",
+    "copyright": "IRC.NET is copyright © 2011-2016 Alex Regueiro, Christian Stewart",
+    "authors": [ "Alexander Regueiro", "Christian Stewart" ],
+    "owners": [ "Alexander Regueiro", "Christian Stewart" ],
+    "tags": [ "communication", "irc", "networking", "ctcp" ],
 
-  "compilationOptions": {
+    "projectUrl": "https://github.com/IrcDotNet/IrcDotNet/",
+    "iconUrl": "https://raw.githubusercontent.com/IrcDotNet/IrcDotNet/master/doc/content/img/logo.png",
+
+    "licenseUrl": "https://github.com/IrcDotNet/IrcDotNet/License.txt",
+    "requireLicenseAcceptance": true
+  },
+
+  "buildOptions": {
     "emitEntryPoint": true
   },
 
   "frameworks": {
-    "net451": { },
-    "dnx451": { }
+    "net451": {},
+    "netcoreapp1.0": {
+      "imports": "dnxcore50",
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "type": "platform",
+          "version": "1.0.0"
+        }
+      },
+      "buildOptions": {
+        "define": [ "NETCOREAPP" ]
+      }
+    }
   },
 
   "dependencies": {
-    "NUnit": "3.0.1",
-    "NUnitLite": "3.0.1",
-    "IrcDotNet": ""
-  },
-
-  "commands": {
-    "IrcDotNet.Test": "IrcDotNet.Test"
+    "NUnit": "3.4.0",
+    "NUnitLite": "3.4.0",
+    "IrcDotNet": {
+      "target": "project"
+    }
   }
 }


### PR DESCRIPTION
This request also provides support for .NET Core 1.0 and support for building and running on Linux and Mac OS X.

All samples are currently compiling under all platforms, except for the TwitterBot sample which has dependencies that only support the full .NET Framework (it compiles fine for Windows only however). 

The test suite runs and passes on Windows, Linux, and Mac OS X.  I also ran the MarkovTextBot sample on both Windows and Mac OS X to smoke test the samples in general.

I have not updated the CI build definitions since I am not familiar enough with them.  Some help here would be appreciated.