### PR TITLE
Implement basic capability negotiation

### DIFF
--- a/source/IrcDotNet/IrcClient.cs
+++ b/source/IrcDotNet/IrcClient.cs
@@ -1568,7 +1568,6 @@ namespace IrcDotNet
 
         protected virtual void HandleClientConnected(IrcRegistrationInfo regInfo)
         {
-            SendMessageCapList();
 
             if (regInfo.Password != null)
                 // Authenticate with server using password.
@@ -1601,6 +1600,8 @@ namespace IrcDotNet
             // Add local user to list of known users.
             lock (((ICollection) Users).SyncRoot)
                 users.Add(localUser);
+
+            SendMessageCapList();
 
             OnConnected(new EventArgs());
         }

--- a/source/IrcDotNet/IrcClientMessageProcessing.cs
+++ b/source/IrcDotNet/IrcClientMessageProcessing.cs
@@ -294,6 +294,44 @@ namespace IrcDotNet
         }
 
         /// <summary>
+        ///     Process CAP messages received from the server.
+        /// </summary>
+        /// <param name="message">The message received from the server.</param>
+        [MessageProcessor("cap")]
+        protected internal void ProcessMessageCap(IrcMessage message)
+        {
+            string subCmd = message.Parameters[1];
+            Debug.Assert(subCmd != null);
+
+            switch (subCmd.ToUpper())
+            {
+                case "LS":
+                    string[] caps = message.Parameters[2]?.Split(' ');
+                    Debug.Assert(caps != null);
+
+                    serverCapabilities.Clear();
+                    serverCapabilities.AddRange(caps);
+
+                    OnServerCapabilitiesReceived(new EventArgs());
+                    break;
+                case "LIST":
+                    string[] active = message.Parameters[2]?.Split(' ');
+                    OnActiveCapabilitiesReceived(new ActiveCapabilitiesEventArgs(active));
+                    break;
+                case "ACK":
+                    string[] ackd = message.Parameters[2]?.Split(' ');
+                    OnCapabilityAcknowledged(new CapabilityAcknowledgedEventArgs(true, ackd));
+                    SendMessageCapEnd();
+                    break;
+                case "NACK":
+                    string[] nakd = message.Parameters[2]?.Split(' ');
+                    OnCapabilityAcknowledged(new CapabilityAcknowledgedEventArgs(false, nakd));
+                    SendMessageCapEnd();
+                    break;
+            }
+        }
+
+        /// <summary>
         ///     Process RPL_WELCOME responses from the server.
         /// </summary>
         /// <param name="message">The message received from the server.</param>

--- a/source/IrcDotNet/IrcClientMessageSending.cs
+++ b/source/IrcDotNet/IrcClientMessageSending.cs
@@ -42,6 +42,42 @@ namespace IrcDotNet
         }
 
         /// <summary>
+        ///     Requests a list of supported capabilities from the server
+        /// </summary>
+        protected void SendMessageCapList()
+        {
+            WriteMessage(null, "CAP", "LS");
+        }
+
+        /// <summary>
+        ///     Requests a list of capabilities associated with the current connection from the server.
+        /// </summary>
+        protected void SendMessageCapListActive()
+        {
+            WriteMessage(null, "CAP", "LIST");
+        }
+
+        /// <summary>
+        ///     Indicates the end of the Capability negotiation process to the server.
+        /// </summary>
+        protected void SendMessageCapEnd()
+        {
+            WriteMessage(null, "CAP", "END");
+        }
+
+        /// <summary>
+        ///     Sends a request to activate a capability to the server
+        /// </summary>
+        /// <param name="caps"></param>
+        protected void SendMessageCapRequest(string[] caps)
+        {
+            if (caps == null || caps.Length == 0)
+                return;
+
+            WriteMessage(null, "CAP", "REQ", string.Join(" ", caps));
+        }
+        
+        /// <summary>
         ///     Sends a request to register the client as a user on the server.
         /// </summary>
         /// <param name="userName">The user name of the user.</param>

--- a/source/IrcDotNet/IrcEventArgs.cs
+++ b/source/IrcDotNet/IrcEventArgs.cs
@@ -521,6 +521,61 @@ namespace IrcDotNet
     }
 
     /// <summary>
+    ///     Provides data for the <see cref="IrcClient.ActiveCapabilitiesReceived" /> event.
+    /// </summary>
+    /// <threadsafety static="true" instance="false" />
+    public class ActiveCapabilitiesEventArgs : EventArgs
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ActiveCapabilitiesEventArgs" /> class.
+        /// </summary>
+        /// <param name="caps">The list of active capabilities</param>
+        public ActiveCapabilitiesEventArgs(string[] caps)
+        {
+            if (caps == null)
+                throw new ArgumentNullException("caps");
+
+            Capabilities = caps;
+        }
+
+        /// <summary>
+        ///     Gets the list of capabilities.
+        /// </summary>
+        /// <value>The list of capabilities.</value>
+        public string[] Capabilities { get; private set; }
+    }
+
+    /// <summary>
+    ///     Provides data for the <see cref="IrcClient.CapabilityAcknowledged" /> event.
+    /// </summary>
+    /// <threadsafety static="true" instance="false" />
+    public class CapabilityAcknowledgedEventArgs : EventArgs
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="CapabilityAcknowledgedEventArgs" /> class.
+        /// </summary>
+        /// <param name="acknowledged">Whether (ACK) or not (NAK) the request has been acknowledged by the server</param>
+        /// <param name="caps">The list of active capabilities</param>
+        public CapabilityAcknowledgedEventArgs(bool acknowledged, string[] caps)
+        {
+            Capabilities = caps;
+            Acknowledged = acknowledged;
+        }
+
+        /// <summary>
+        ///     Gets the list of capabilities.
+        /// </summary>
+        /// <value>The list of capabilities.</value>
+        public string[] Capabilities { get; private set; }
+
+        /// <summary>
+        ///     Gets whether (ACK) or not (NAK) the request has been acknowledged by the server.
+        /// </summary>
+        /// <value>Whether (ACK) or not (NAK) the request has been acknowledged by the server.</value>
+        public bool Acknowledged { get; private set; }
+    }
+
+    /// <summary>
     ///     Provides data for the <see cref="IrcClient.ProtocolError" /> event.
     /// </summary>
     /// <threadsafety static="true" instance="false" />


### PR DESCRIPTION
Adds two public methods to IrcClient, RequestCapability and
RequestActiveCapabilities, with which capability negotiation can be
accomplished. Also, the client now issues a CAP LS command upon a
successful connection and caches the result in the IrcClient class.

See #37.