### PR TITLE
change IRC commands to uppercase

### DIFF
--- a/source/IrcDotNet/IrcClient.cs
+++ b/source/IrcDotNet/IrcClient.cs
@@ -1914,7 +1914,7 @@ namespace IrcDotNet
             public IrcMessage(IrcClient client, string prefix, string command, IList<string> parameters)
             {
                 Prefix = prefix;
-                Command = command;
+                Command = command.ToUpper();
                 Parameters = parameters;
 
                 Source = client.GetSourceFromPrefix(prefix);


### PR DESCRIPTION
The RFC specifies all commands to be uppercase, so for conformity they should be sent as uppercase by the library aswell.
Example references: 
https://tools.ietf.org/html/rfc2812#section-3.1.2
https://tools.ietf.org/html/rfc2812#section-3.2.1 (also see "Examples")

See #38 