### PR TITLE
Add WhoX (extended who) command.

### DIFF
--- a/source/IrcDotNet/IrcClient.cs
+++ b/source/IrcDotNet/IrcClient.cs
@@ -399,6 +399,11 @@ namespace IrcDotNet
         public event EventHandler<IrcNameEventArgs> WhoReplyReceived;
 
         /// <summary>
+        ///     Occurs when a reply to a WhoX query has been received from the server.
+        /// </summary>
+        public event EventHandler<IrcRawMessageEventArgs> WhoXReplyReceived;
+
+        /// <summary>
         ///     Occurs when a reply to a Who Is query has been received from the server.
         /// </summary>
         public event EventHandler<IrcUserEventArgs> WhoIsReplyReceived;
@@ -570,6 +575,28 @@ namespace IrcDotNet
             CheckDisposed();
 
             SendMessageWho(mask, onlyOperators);
+        }
+
+        /// <summary>
+        ///     Sends a WhoX query to the server targeting the specified channel or user masks.
+        /// </summary>
+        /// <param name="mask">
+        ///     A wildcard expression for matching against channel names; or if none can be found,
+        ///     host names, server names, real names, and nick names of users. If the value is <see langword="null" />,
+        ///     all users are matched.
+        /// </param>
+        /// <param name="flags">
+        ///     Flags for requesting specific data, see http://faerion.sourceforge.net/doc/irc/whox.var.
+        /// </param>
+        /// <param name="mask2">
+        ///     A second mask field, which can contain spaces and overrides the first mask field.
+        /// </param>
+        /// <exception cref="ObjectDisposedException">The current instance has already been disposed.</exception>
+        public void QueryWhoX(string mask = null, string flags = null, string mask2 = null)
+        {
+            CheckDisposed();
+
+            SendMessageWhoX(mask, flags, mask2);
         }
 
         /// <inheritdoc cref="QueryWhoIs(IEnumerable{string})" />
@@ -1810,6 +1837,17 @@ namespace IrcDotNet
         protected virtual void OnWhoReplyReceived(IrcNameEventArgs e)
         {
             var handler = WhoReplyReceived;
+            if (handler != null)
+                handler(this, e);
+        }
+
+        /// <summary>
+        ///     Raises the <see cref="WhoXReplyReceived" /> event.
+        /// </summary>
+        /// <param name="e">The <see cref="IrcRawMessageEventArgs" /> instance containing the event data.</param>
+        protected virtual void OnWhoXReplyReceived(IrcRawMessageEventArgs e)
+        {
+            var handler = WhoXReplyReceived;
             if (handler != null)
                 handler(this, e);
         }

--- a/source/IrcDotNet/IrcClientMessageProcessing.cs
+++ b/source/IrcDotNet/IrcClientMessageProcessing.cs
@@ -1042,6 +1042,18 @@ namespace IrcDotNet
         }
 
         /// <summary>
+        ///     Process RPL_WHOSPCRPL responses from the server.
+        /// </summary>
+        /// <param name="message">The message received from the server.</param>
+        [MessageProcessor("354")]
+        protected internal void ProcessMessageReplyWhoXReply(IrcMessage message)
+        {
+            Debug.Assert(message.Parameters[0] == localUser.NickName);
+
+            OnWhoXReplyReceived(new IrcRawMessageEventArgs(message, message.Parameters[1]));
+        }
+
+        /// <summary>
         ///     Process RPL_LINKS responses from the server.
         /// </summary>
         /// <param name="message">The message received from the server.</param>

--- a/source/IrcDotNet/IrcClientMessageSending.cs
+++ b/source/IrcDotNet/IrcClientMessageSending.cs
@@ -443,6 +443,25 @@ namespace IrcDotNet
         }
 
         /// <summary>
+        ///     Sends a WhoX query to the server targeting the specified channel or user masks.
+        /// </summary>
+        /// <param name="mask">
+        ///     A wildcard expression for matching against channel names; or if none can be found,
+        ///     host names, server names, real names, and nick names of users. If the value is <see langword="null" />,
+        ///     all users are matched.
+        /// </param>
+        /// <param name="flags">
+        ///     Flags for requesting specific data, see http://faerion.sourceforge.net/doc/irc/whox.var.
+        /// </param>
+        /// <param name="mask2">
+        ///     A second mask field, which can contain spaces and overrides the first mask field.
+        /// </param>
+        protected void SendMessageWhoX(string mask = null, string flags = null, string mask2 = null)
+        {
+            WriteMessage(null, "who", mask, flags, mask2);
+        }
+
+        /// <summary>
         ///     Sends a request to perform a WhoIs query on users.
         /// </summary>
         /// <param name="nickNameMasks">


### PR DESCRIPTION
Adds extended 'Who' command available on some servers (some info: http://faerion.sourceforge.net/doc/irc/whox.var). Not sure if this command is wanted since it might not be used everywhere, but I use it in my IRC bot so I figured I'd submit it.

I've only tested it on the .NET framework version of IrcDotNet but as far as I can tell it will work fine with the .NET standard changes.