### PR TITLE
Add support for connecting to znc bouncer

### DIFF
--- a/source/IrcDotNet/IrcClient.cs
+++ b/source/IrcDotNet/IrcClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -1547,11 +1547,23 @@ namespace IrcDotNet
                 // Register client as normal user.
                 var userRegInfo = (IrcUserRegistrationInfo) regInfo;
                 SendMessageNick(userRegInfo.NickName);
-                SendMessageUser(userRegInfo.UserName, GetNumericUserMode(userRegInfo.UserModes),
-                    userRegInfo.RealName);
 
-                localUser = new IrcLocalUser(userRegInfo.NickName, userRegInfo.UserName, userRegInfo.RealName,
-                    userRegInfo.UserModes);
+                if (userRegInfo is ZncRegistrationInfo zncRegistrationInfo)
+                {
+                    var zncUsernameAndNetwork = $"{zncRegistrationInfo.ZncUsername}/{zncRegistrationInfo.Network}";
+                    SendMessageUser(zncUsernameAndNetwork, GetNumericUserMode(zncRegistrationInfo.UserModes),
+                        zncRegistrationInfo.RealName);
+                    localUser = new IrcLocalUser(zncRegistrationInfo.NickName, zncUsernameAndNetwork, zncRegistrationInfo.RealName,
+                        zncRegistrationInfo.UserModes);
+                }
+                else
+                {
+                    SendMessageUser(userRegInfo.UserName, GetNumericUserMode(userRegInfo.UserModes),
+                        userRegInfo.RealName);
+                    localUser = new IrcLocalUser(userRegInfo.NickName, userRegInfo.UserName, userRegInfo.RealName,
+                        userRegInfo.UserModes);
+                }
+
             }
             localUser.Client = this;
 

--- a/source/IrcDotNet/IrcRegistrationInfo.cs
+++ b/source/IrcDotNet/IrcRegistrationInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace IrcDotNet
 {
@@ -23,6 +23,12 @@ namespace IrcDotNet
         /// </summary>
         /// <value>A description of the service.</value>
         public string Description { get; set; }
+    }
+
+    public class ZncRegistrationInfo : IrcUserRegistrationInfo
+    {
+        public string Network { get; set; }
+        public string ZncUsername { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
In order to connect to znc, two extra pieces of data are needed: znc username and password. I have modified IrcClient to allow connecting to znc using ZncRegistrationInfo:
`                registrationInfo = new ZncRegistrationInfo
                {
                    Network = "freenode",
                    NickName = "ircBot",
                    Password = "pass",
                    RealName = "ircBot",
                    UserName = "ircBot",
                    ZncUsername = "zncuser"
                };
               Connect("znc.address.com", 13445, registrationInfo);`